### PR TITLE
resources/bulk converts content from base64

### DIFF
--- a/src/Rhino.Controllers/Controllers/ResourcesController.cs
+++ b/src/Rhino.Controllers/Controllers/ResourcesController.cs
@@ -3,10 +3,12 @@
  * 
  * RESSOURCES
  */
+using Gravity.Extensions;
 using Gravity.Services.DataContracts;
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.VisualStudio.Services.Commerce;
 
 using Rhino.Api.Contracts.Configuration;
 using Rhino.Controllers.Domain;
@@ -18,9 +20,11 @@ using Rhino.Settings;
 
 using Swashbuckle.AspNetCore.Annotations;
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Mime;
+using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 
@@ -149,7 +153,14 @@ namespace Rhino.Controllers.Controllers
             {
                 return BadRequest(ModelState);
             }
-
+            foreach (var item in resourceModels)
+            {
+                var buffer = new Span<byte>(new byte[item.Content.Length]);
+                if (Convert.TryFromBase64String(item.Content, buffer, out var _))
+                {
+                    item.Content = Encoding.UTF8.GetString(buffer);
+                }
+            }
             // setup
             var entities = resourceModels
                 .Select(_domain.Resources.Create)

--- a/src/Rhino.Controllers/Controllers/ResourcesController.cs
+++ b/src/Rhino.Controllers/Controllers/ResourcesController.cs
@@ -153,6 +153,8 @@ namespace Rhino.Controllers.Controllers
             {
                 return BadRequest(ModelState);
             }
+
+            //Convert resource content from base64
             foreach (var item in resourceModels)
             {
                 var buffer = new Span<byte>(new byte[item.Content.Length]);
@@ -161,6 +163,7 @@ namespace Rhino.Controllers.Controllers
                     item.Content = Encoding.UTF8.GetString(buffer);
                 }
             }
+
             // setup
             var entities = resourceModels
                 .Select(_domain.Resources.Create)


### PR DESCRIPTION
POST resources/bulk
now expects resources content to be in base64 and converts from base64 prior to creation of resource.